### PR TITLE
Enforce minimum entry duration

### DIFF
--- a/electron-app/src/renderer/src/components/CalendarWidget/DayTimeline/DayTimeline.tsx
+++ b/electron-app/src/renderer/src/components/CalendarWidget/DayTimeline/DayTimeline.tsx
@@ -384,12 +384,15 @@ export const DayTimeline = ({
         newEndTime.setMinutes(newEndTime.getMinutes() + deltaMinutes)
       }
 
-      // Basic validation
-      if (newEndTime <= newStartTime) {
+      // Basic validation - enforce minimum 5 minute duration
+      const minDurationMs = 5 * 60 * 1000; // 5 minutes
+      const currentDurationMs = newEndTime.getTime() - newStartTime.getTime();
+      
+      if (currentDurationMs < minDurationMs) {
         if (direction === 'top') {
-          newStartTime = new Date(newEndTime.getTime() - 60000) // 1 min duration
+          newStartTime = new Date(newEndTime.getTime() - minDurationMs);
         } else {
-          newEndTime = new Date(newStartTime.getTime() + 60000) // 1 min duration
+          newEndTime = new Date(newStartTime.getTime() + minDurationMs);
         }
       }
 


### PR DESCRIPTION
Enforce a minimum 5-minute duration for manual entries to prevent them from being resized to 0 minutes.

---

[Open in Web](https://cursor.com/agents?id=bc-833d1b19-2b82-4ad1-be3f-4117e038bf5f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-833d1b19-2b82-4ad1-be3f-4117e038bf5f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)