### PR TITLE
Trigger Screenshot only on active window change not every 30s

### DIFF
--- a/electron-app/src/native-modules/native-windows/macos/ScreenshotManager.mm
+++ b/electron-app/src/native-modules/native-windows/macos/ScreenshotManager.mm
@@ -20,14 +20,8 @@
 - (void)startPeriodicScreenshotCapture {
     [self stopPeriodicScreenshotCapture];
     
-    // Take screenshot every 30 seconds
-    screenshotTimer = [NSTimer scheduledTimerWithTimeInterval:30.0
-                                                     target:self
-                                                   selector:@selector(takeScreenshot)
-                                                   userInfo:nil
-                                                    repeats:YES];
-    [[NSRunLoop currentRunLoop] addTimer:screenshotTimer forMode:NSRunLoopCommonModes];
-    MyLog(@"Screenshot timer started");
+    // Remove the periodic timer logic
+    MyLog(@"Screenshot capture will be triggered by window changes");
 }
 
 - (void)stopPeriodicScreenshotCapture {

--- a/electron-app/src/native-modules/native-windows/macos/activeWindowObserver.mm
+++ b/electron-app/src/native-modules/native-windows/macos/activeWindowObserver.mm
@@ -65,6 +65,10 @@ void windowChangeCallback(AXObserverRef observer, AXUIElementRef element, CFStri
                     }
                 }
             }
+            // Trigger screenshot capture and OCR
+            ScreenshotManager *screenshotManager = [[ScreenshotManager alloc] init];
+            [screenshotManager takeScreenshot];
+            [screenshotManager release];
         });
     }
 }


### PR DESCRIPTION
Note: was not able to test locally, doesn't seem like ScreenshotManager.mm or activeWindowObserver.mm is getting called from anywhere in the js code, didn't even see the logs

Should also be triggered on internal tab changes in browsers, but didn't get the chance to test